### PR TITLE
Allow lambda syntax for typescript receivers implemented as classes.

### DIFF
--- a/src/TypedSignalR.Client.TypeScript/ApiGenerator.cs
+++ b/src/TypedSignalR.Client.TypeScript/ApiGenerator.cs
@@ -66,10 +66,13 @@ internal class ApiGenerator
             sb.AppendLine($"import {{ {string.Join(", ", group.Select(x => x.Name))} }} from './{group.Key.ToDisplayString()}';");
         }
 
-        var appearTypes = hubTypes.SelectMany(static x => x.GetMethods())
+        var hubParametersAndReturnTypes = hubTypes.SelectMany(static x => x.GetMethods())
             .SelectMany(static x => x.Parameters.Select(static y => y.Type).Concat(new[] { GetReturnType(x) }));
 
-        var tapperAttributeAnnotatedTypesLookup = appearTypes
+        var receiverParameterTypes = receiverTypes.SelectMany(static x => x.GetMethods())
+            .SelectMany(static x => x.Parameters.Select(static y => y.Type));
+
+        var tapperAttributeAnnotatedTypesLookup = hubParametersAndReturnTypes.Concat(receiverParameterTypes)
             .OfType<INamedTypeSymbol>()
             .Where(x => x.IsAttributeAnnotated(_specialSymbols.TranspilationSourceAttributeSymbol))
             .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)

--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
@@ -147,8 +147,8 @@ export type HubProxyFactoryProvider = {
  foreach(var method in receiverType.Methods) { 
             this.Write("        connection.on(\"");
             this.Write(this.ToStringHelper.ToStringWithCulture(method.Name));
-            this.Write("\", receiver.");
-            this.Write(this.ToStringHelper.ToStringWithCulture(method.Name.Format(TranspilationOptions.NamingStyle)));
+            this.Write("\", ");
+            this.Write(this.ToStringHelper.ToStringWithCulture(method.ToLambdaEvent(TranspilationOptions)));
             this.Write(");\r\n");
  } 
             this.Write("\r\n        const methodList: ReceiverMethod[] = [\r\n");

--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
@@ -113,7 +113,7 @@ class <#= receiverType.Name #>_Binder implements ReceiverRegister<<#= receiverTy
     public readonly register = (connection: HubConnection, receiver: <#= receiverType.Name #>): Disposable => {
 
 <# foreach(var method in receiverType.Methods) { #>
-        connection.on("<#= method.Name #>", receiver.<#= method.Name.Format(TranspilationOptions.NamingStyle) #>);
+        connection.on("<#= method.Name #>", <#= method.ToLambdaEvent(TranspilationOptions) #>);
 <# } #>
 
         const methodList: ReceiverMethod[] = [

--- a/src/TypedSignalR.Client.TypeScript/Templates/MetadataExtensions.cs
+++ b/src/TypedSignalR.Client.TypeScript/Templates/MetadataExtensions.cs
@@ -17,4 +17,11 @@ internal static class MetadataExtensions
     {
         return TypeMapper.MapTo(methodSymbol.ReturnType, options);
     }
+
+    public static string ToLambdaEvent(this IMethodSymbol methodSymbol, ITranspilationOptions options)
+    {
+        var parameters = methodSymbol.ParametersToTypeScriptString(options);
+        var parametersWithoutType = string.Join(",", methodSymbol.Parameters.Select(static x => x.Name));
+        return $"({parameters}) => receiver.{methodSymbol.Name.Format(options.NamingStyle)}({parametersWithoutType})";
+    }
 }

--- a/tests/TypeScriptTests/src/receiverAsClass.test.ts
+++ b/tests/TypeScriptTests/src/receiverAsClass.test.ts
@@ -1,0 +1,97 @@
+import { HubConnectionBuilder } from '@microsoft/signalr'
+import { getHubProxyFactory, getReceiverRegister } from './generated/TypedSignalR.Client'
+import { UserDefinedType } from './generated/TypedSignalR.Client.TypeScript.Tests.Shared';
+import { IReceiver } from './generated/TypedSignalR.Client/TypedSignalR.Client.TypeScript.Tests.Shared';
+
+const toUTCString = (date: string | Date): string => {
+    if (typeof date === 'string') {
+        const d = new Date(date);
+        return d.toUTCString();
+    }
+
+    return date.toUTCString();
+}
+
+const answerMessages: string[] = [
+    "b1f7cd73-13b8-49bd-9557-ffb38859d18b",
+    "3f5c3585-d01b-4f8f-8139-62a1241850e2",
+    "92021a22-5823-4501-8cbd-c20d4ca6e54c",
+    "5b134f73-2dc1-4271-8316-1a4250f42241",
+    "e73acd30-e034-4569-8f30-88ac34b99052",
+    "0d7531b5-0a36-4fe7-bbe5-8fee38c38c07",
+    "32915627-3df6-41dc-8d30-7c655c2f7e61",
+    "c875a6f9-9ddb-440b-a7e4-6e893f59ab9e",
+];
+
+const guids: string[] = [
+    "b2f626e5-b4d4-4713-891d-f6cb107e502e",
+    "22733524-2087-4701-a586-c6bf0ce36f74",
+    "b89324bf-daf2-422a-85f2-6843b9c09b6a",
+    "779769d1-0aee-4dba-82c7-9e1044836d75"
+];
+
+const dateTimes: string[] = [
+    "2017-04-17",
+    "2018-05-25",
+    "2019-03-31",
+    "2022-02-06",
+];
+
+class ReceiverAsClass implements IReceiver  
+{
+    public receiveMessageList: [string, number][] = []; 
+    public notifyCallCount: number = 0;
+    public userDefinedList: UserDefinedType[] = [];
+
+    receiveMessage(message: string, value: number): Promise<void> {
+        this.receiveMessageList.push([message, value]);
+        return Promise.resolve();
+    }
+    nofity(): Promise<void> {
+        this.notifyCallCount += 1;
+        return Promise.resolve();
+    }
+    receiveCustomMessage(userDefined: UserDefinedType): Promise<void> {
+        this.userDefinedList.push(userDefined)
+        return Promise.resolve();
+    }
+    
+}
+
+const testMethod = async () => {
+    const connection = new HubConnectionBuilder()
+        .withUrl("http://localhost:5000/realtime/receivertesthub")
+        .build();
+
+    const receiver = new ReceiverAsClass();
+
+    const hubProxy = getHubProxyFactory("IReceiverTestHub")
+        .createHubProxy(connection);
+
+    const subscription = getReceiverRegister("IReceiver")
+        .register(connection, receiver);
+
+    await connection.start();
+    await hubProxy.start();
+
+    const receiveMessageList = receiver.receiveMessageList;
+    const userDefinedList = receiver.userDefinedList;
+    const notifyCallCount = receiver.notifyCallCount;
+
+    expect(notifyCallCount).toEqual(17);
+
+    for (let i = 0; i < receiveMessageList.length; i++) {
+        expect(receiveMessageList[i][0]).toEqual(answerMessages[i]);
+        expect(receiveMessageList[i][1]).toEqual(i);
+    }
+
+    for (let i = 0; i < userDefinedList.length; i++) {
+        expect(userDefinedList[i].guid).toEqual(guids[i]);
+        expect(toUTCString(userDefinedList[i].dateTime)).toEqual(toUTCString(dateTimes[i]));
+    }
+
+    subscription.dispose();
+    await connection.stop()
+}
+
+test('receiver.test', testMethod);


### PR DESCRIPTION
This PR will allow typescript receivers implemented as typescript classes to use `this.` notation in the handlers for the events.

The `receiverAsClass.test.ts` tests that the generated event handlers still work as expected.

Feel free to comment if I have missed anything.