### PR TITLE
fix header generation

### DIFF
--- a/src/TypedSignalR.Client.TypeScript/ApiGenerator.cs
+++ b/src/TypedSignalR.Client.TypeScript/ApiGenerator.cs
@@ -69,6 +69,7 @@ internal class ApiGenerator
             );
 
         var tapperAttributeAnnotatedTypesLookup = hubParametersAndReturnTypes.Concat(receiverParameterTypes)
+            .SelectMany(RoslynExtensions.GetRelevantTypes)
             .OfType<INamedTypeSymbol>()
             .Where(x => x.IsAttributeAnnotated(_specialSymbols.TranspilationSourceAttributeSymbols))
             .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)

--- a/src/TypedSignalR.Client.TypeScript/InterfaceTranspiler.cs
+++ b/src/TypedSignalR.Client.TypeScript/InterfaceTranspiler.cs
@@ -64,6 +64,7 @@ internal class InterfaceTranspiler
             );
 
         var tapperAttributeAnnotatedTypesLookup = appearTypes
+            .SelectMany(RoslynExtensions.GetRelevantTypes)
             .OfType<INamedTypeSymbol>()
             .Where(x => x.IsAttributeAnnotated(_specialSymbols.TranspilationSourceAttributeSymbols))
             .Distinct<INamedTypeSymbol>(SymbolEqualityComparer.Default)

--- a/src/TypedSignalR.Client.TypeScript/RoslynExtensions.cs
+++ b/src/TypedSignalR.Client.TypeScript/RoslynExtensions.cs
@@ -62,6 +62,42 @@ internal static partial class RoslynExtensions
             });
     }
 
+    public static IEnumerable<ITypeSymbol> GetRelevantTypes(this ITypeSymbol typeSymbol)
+    {
+        if (typeSymbol is INamedTypeSymbol namedTypeSymbol)
+        {
+            if (namedTypeSymbol.IsGenericType)
+            {
+                yield return namedTypeSymbol;
+
+                foreach (var typeArgument in namedTypeSymbol.TypeArguments)
+                {
+                    foreach (var it in GetRelevantTypes(typeArgument))
+                    {
+                        yield return it;
+                    }
+                }
+            }
+            else
+            {
+                yield return namedTypeSymbol;
+            }
+        }
+        else if (typeSymbol is IArrayTypeSymbol arrayTypeSymbol)
+        {
+            var elementType = arrayTypeSymbol.ElementType;
+
+            foreach (var it in GetRelevantTypes(elementType))
+            {
+                yield return it;
+            }
+        }
+        else
+        {
+            yield return typeSymbol;
+        }
+    }
+
     public static bool IsAttributeAnnotated(this INamedTypeSymbol source, INamedTypeSymbol attributeSymbol)
     {
         return source.GetAttributes()

--- a/tests/TypeScriptTests/src/json/unary.test.ts
+++ b/tests/TypeScriptTests/src/json/unary.test.ts
@@ -1,6 +1,6 @@
 import { HubConnectionBuilder } from '@microsoft/signalr'
 import { getHubProxyFactory } from '../generated/json/TypedSignalR.Client'
-import { MyEnum, UserDefinedType } from '../generated/json/TypedSignalR.Client.TypeScript.Tests.Shared';
+import { MyEnum, MyRequestItem, MyRequestItem2, UserDefinedType } from '../generated/json/TypedSignalR.Client.TypeScript.Tests.Shared';
 import crypto from 'crypto'
 
 const getRandomInt = (max: number) => {
@@ -57,6 +57,28 @@ const testMethod = async () => {
 
         const r5 = await hubProxy.echoMyEnum(MyEnum.Four);
         expect(r5).toEqual(MyEnum.Four)
+
+        const array: MyRequestItem[] = []
+        array.push({ text: "melonpan" })
+        array.push({ text: "banana" })
+
+        const r6 = await hubProxy.requestArray(array);
+
+        expect(r6.length).toEqual(2)
+        expect(r6[0].text).toEqual("melonpanmelonpan")
+        expect(r6[1].text).toEqual("bananabanana")
+
+        const list: MyRequestItem2[] = []
+        list.push({ id: "14ba25de-0a67-4713-8d29-59bcbec1c194" })
+        list.push({ id: "7e0ddf0a-2e55-4a32-98a0-049e12a4d728" })
+        list.push({ id: "b237bcb2-053a-4d4a-8868-6e78ca651ecd" })
+
+        const r7 = await hubProxy.requestList(list);
+
+        expect(r7.length).toEqual(3)
+        expect(r7[0].id).toEqual("b237bcb2-053a-4d4a-8868-6e78ca651ecd")
+        expect(r7[1].id).toEqual("7e0ddf0a-2e55-4a32-98a0-049e12a4d728")
+        expect(r7[2].id).toEqual("14ba25de-0a67-4713-8d29-59bcbec1c194")
     }
     finally {
         await connection.stop();

--- a/tests/TypeScriptTests/src/msgpack/unary.test.ts
+++ b/tests/TypeScriptTests/src/msgpack/unary.test.ts
@@ -1,20 +1,11 @@
 import { HubConnectionBuilder } from '@microsoft/signalr'
 import { getHubProxyFactory } from '../generated/msgpack/TypedSignalR.Client'
-import { MyEnum, UserDefinedType } from '../generated/msgpack/TypedSignalR.Client.TypeScript.Tests.Shared';
+import { MyEnum, MyRequestItem, MyRequestItem2, UserDefinedType } from '../generated/msgpack/TypedSignalR.Client.TypeScript.Tests.Shared';
 import crypto from 'crypto'
 import { MessagePackHubProtocol } from '@microsoft/signalr-protocol-msgpack';
 
 const getRandomInt = (max: number) => {
     return Math.floor(Math.random() * max);
-}
-
-const toUTCString = (date: string | Date): string => {
-    if (typeof date === 'string') {
-        const d = new Date(date);
-        return d.toUTCString();
-    }
-
-    return date.toUTCString();
 }
 
 const testMethod = async () => {
@@ -61,6 +52,28 @@ const testMethod = async () => {
         const r5 = await hubProxy.echoMyEnum(MyEnum.Four);
 
         expect(r5).toEqual(MyEnum.Four)
+
+        const array: MyRequestItem[] = []
+        array.push({ Text: "melonpan" })
+        array.push({ Text: "banana" })
+
+        const r6 = await hubProxy.requestArray(array);
+
+        expect(r6.length).toEqual(2)
+        expect(r6[0].Text).toEqual("melonpanmelonpan")
+        expect(r6[1].Text).toEqual("bananabanana")
+
+        const list: MyRequestItem2[] = []
+        list.push({ Id: "14ba25de-0a67-4713-8d29-59bcbec1c194" })
+        list.push({ Id: "7e0ddf0a-2e55-4a32-98a0-049e12a4d728" })
+        list.push({ Id: "b237bcb2-053a-4d4a-8868-6e78ca651ecd" })
+
+        const r7 = await hubProxy.requestList(list);
+
+        expect(r7.length).toEqual(3)
+        expect(r7[0].Id).toEqual("b237bcb2-053a-4d4a-8868-6e78ca651ecd")
+        expect(r7[1].Id).toEqual("7e0ddf0a-2e55-4a32-98a0-049e12a4d728")
+        expect(r7[2].Id).toEqual("14ba25de-0a67-4713-8d29-59bcbec1c194")
     }
     finally {
         await connection.stop();

--- a/tests/TypeScriptTests/src/msgpack/unary.test.ts
+++ b/tests/TypeScriptTests/src/msgpack/unary.test.ts
@@ -70,7 +70,7 @@ const testMethod = async () => {
 
         const r7 = await hubProxy.requestList(list);
 
-        expect(r7.length).toEqual(3)
+        expect(r7.length).toEqual(2)
         expect(r7[0].Id).toEqual("b237bcb2-053a-4d4a-8868-6e78ca651ecd")
         expect(r7[1].Id).toEqual("7e0ddf0a-2e55-4a32-98a0-049e12a4d728")
         expect(r7[2].Id).toEqual("14ba25de-0a67-4713-8d29-59bcbec1c194")

--- a/tests/TypeScriptTests/src/msgpack/unary.test.ts
+++ b/tests/TypeScriptTests/src/msgpack/unary.test.ts
@@ -70,7 +70,7 @@ const testMethod = async () => {
 
         const r7 = await hubProxy.requestList(list);
 
-        expect(r7.length).toEqual(2)
+        expect(r7.length).toEqual(3)
         expect(r7[0].Id).toEqual("b237bcb2-053a-4d4a-8868-6e78ca651ecd")
         expect(r7[1].Id).toEqual("7e0ddf0a-2e55-4a32-98a0-049e12a4d728")
         expect(r7[2].Id).toEqual("14ba25de-0a67-4713-8d29-59bcbec1c194")

--- a/tests/TypedSignalR.Client.TypeScript.Tests.Server/Hubs/UnaryHub.cs
+++ b/tests/TypedSignalR.Client.TypeScript.Tests.Server/Hubs/UnaryHub.cs
@@ -45,4 +45,34 @@ public class UnaryHub : Hub, IUnaryHub
 
         return Task.FromResult("TypedSignalR.Client.TypeScript");
     }
+
+    public Task<MyResponseItem[]> RequestArray(MyRequestItem[] array)
+    {
+        var buffer = new MyResponseItem[array.Length];
+
+        for (int i = 0; i < array.Length; i++)
+        {
+            buffer[i] = new MyResponseItem
+            {
+                Text = $"{array[i].Text}{array[i].Text}"
+            };
+        }
+
+        return Task.FromResult(buffer);
+    }
+
+    public Task<List<MyResponseItem2>> RequestList(List<MyRequestItem2> list)
+    {
+        var buffer = new List<MyResponseItem2>(list.Count);
+
+        for (int i = 0; i < list.Count; i++)
+        {
+            buffer.Add(new MyResponseItem2
+            {
+                Id = list[list.Count - 1 - i].Id
+            });
+        }
+
+        return Task.FromResult(buffer);
+    }
 }

--- a/tests/TypedSignalR.Client.TypeScript.Tests.Shared/IUnaryHub.cs
+++ b/tests/TypedSignalR.Client.TypeScript.Tests.Shared/IUnaryHub.cs
@@ -18,6 +18,30 @@ public enum MyEnum
     Four = 4,
 }
 
+[TranspilationSource]
+public class MyRequestItem
+{
+    public string? Text { get; init; }
+}
+
+[TranspilationSource]
+public class MyResponseItem
+{
+    public required string Text { get; init; }
+}
+
+[TranspilationSource]
+public class MyRequestItem2
+{
+    public required Guid Id { get; init; }
+}
+
+[TranspilationSource]
+public class MyResponseItem2
+{
+    public Guid Id { get; init; }
+}
+
 [Hub]
 public interface IUnaryHub
 {
@@ -26,4 +50,6 @@ public interface IUnaryHub
     Task<string> Cat(string x, string y);
     Task<UserDefinedType> Echo(UserDefinedType instance);
     Task<MyEnum> EchoMyEnum(MyEnum myEnum);
+    Task<MyResponseItem[]> RequestArray(MyRequestItem[] array);
+    Task<List<MyResponseItem2>> RequestList(List<MyRequestItem2> list);
 }


### PR DESCRIPTION
Fixed an issue in which headers were not generated correctly when collections such as `T[]` and `List<T>` were used as the parameter or return type of methods.