### PR TITLE
support netstandard2.0

### DIFF
--- a/src/TypedSignalR.Client.TypeScript.Generator/App.cs
+++ b/src/TypedSignalR.Client.TypeScript.Generator/App.cs
@@ -98,8 +98,21 @@ public class App : ConsoleAppBase
 
         typeMapperProvider.AddTypeMapper(new TaskTypeMapper(compilation));
         typeMapperProvider.AddTypeMapper(new GenericTaskTypeMapper(compilation));
-        typeMapperProvider.AddTypeMapper(new AsyncEnumerableTypeMapper(compilation));
-        typeMapperProvider.AddTypeMapper(new ChannelReaderTypeMapper(compilation));
+
+        // By default, netstandard2.0 does not include IAsyncEnumerable<T> and ChannelReader<T>
+        var asyncEnumerableTypeMapper = new AsyncEnumerableTypeMapper(compilation);
+
+        if (asyncEnumerableTypeMapper.IsSupported())
+        {
+            typeMapperProvider.AddTypeMapper(asyncEnumerableTypeMapper);
+        }
+
+        var channelReaderTypeMapper = new ChannelReaderTypeMapper(compilation);
+
+        if (channelReaderTypeMapper.IsSupported())
+        {
+            typeMapperProvider.AddTypeMapper(channelReaderTypeMapper);
+        }
 
         var options = new TypedSignalRTranspilationOptions(
             compilation,

--- a/src/TypedSignalR.Client.TypeScript/RoslynExtensions.TypeCollector.cs
+++ b/src/TypedSignalR.Client.TypeScript/RoslynExtensions.TypeCollector.cs
@@ -130,9 +130,18 @@ internal static partial class RoslynExtensions
                     var typeArg = namedTypeSymbol.TypeArguments[0] as INamedTypeSymbol;
 
                     // Task<IAsyncEnumerable<T>> -> T
+                    // NOTE:
+                    //     SymbolEqualityComparer.Default.Equals(null, null) return true,
+                    //     so verify that specialSymbols.AsyncEnumerableSymbol is not null first.
+                    if (specialSymbols.AsyncEnumerableSymbol is not null
+                        && SymbolEqualityComparer.Default.Equals(typeArg?.OriginalDefinition, specialSymbols.AsyncEnumerableSymbol))
+                    {
+                        return typeArg.TypeArguments[0];
+                    }
+
                     // Task<ChannelReader<T>> -> T
-                    if (SymbolEqualityComparer.Default.Equals(typeArg?.OriginalDefinition, specialSymbols.AsyncEnumerableSymbol)
-                        || SymbolEqualityComparer.Default.Equals(typeArg?.OriginalDefinition, specialSymbols.ChannelReaderSymbol))
+                    if (specialSymbols.ChannelReaderSymbol is not null
+                        && SymbolEqualityComparer.Default.Equals(typeArg?.OriginalDefinition, specialSymbols.ChannelReaderSymbol))
                     {
                         return typeArg.TypeArguments[0];
                     }

--- a/src/TypedSignalR.Client.TypeScript/SpecialSymbols.cs
+++ b/src/TypedSignalR.Client.TypeScript/SpecialSymbols.cs
@@ -8,9 +8,9 @@ internal class SpecialSymbols
 {
     public readonly INamedTypeSymbol TaskSymbol;
     public readonly INamedTypeSymbol GenericTaskSymbol;
-    public readonly INamedTypeSymbol AsyncEnumerableSymbol;
-    public readonly INamedTypeSymbol ChannelReaderSymbol;
     public readonly INamedTypeSymbol CancellationTokenSymbol;
+    public readonly INamedTypeSymbol? AsyncEnumerableSymbol;
+    public readonly INamedTypeSymbol? ChannelReaderSymbol;
     public readonly ImmutableArray<INamedTypeSymbol> HubAttributeSymbols;
     public readonly ImmutableArray<INamedTypeSymbol> ReceiverAttributeSymbols;
     public readonly ImmutableArray<INamedTypeSymbol> TranspilationSourceAttributeSymbols;
@@ -19,9 +19,9 @@ internal class SpecialSymbols
     {
         TaskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task")!;
         GenericTaskSymbol = compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1")!;
-        AsyncEnumerableSymbol = compilation.GetTypeByMetadataName("System.Collections.Generic.IAsyncEnumerable`1")!;
-        ChannelReaderSymbol = compilation.GetTypeByMetadataName("System.Threading.Channels.ChannelReader`1")!;
         CancellationTokenSymbol = compilation.GetTypeByMetadataName("System.Threading.CancellationToken")!;
+        AsyncEnumerableSymbol = compilation.GetTypeByMetadataName("System.Collections.Generic.IAsyncEnumerable`1");
+        ChannelReaderSymbol = compilation.GetTypeByMetadataName("System.Threading.Channels.ChannelReader`1");
 
         var hubAttributeSymbol = compilation.GetTypesByMetadataName("TypedSignalR.Client.HubAttribute");
         var receiverAttributeSymbol = compilation.GetTypesByMetadataName("TypedSignalR.Client.ReceiverAttribute");

--- a/src/TypedSignalR.Client.TypeScript/TypeMappers/StreamTypeMapper.cs
+++ b/src/TypedSignalR.Client.TypeScript/TypeMappers/StreamTypeMapper.cs
@@ -26,6 +26,11 @@ public sealed class AsyncEnumerableTypeMapper : ITypeMapper
 
         throw new InvalidOperationException($"GenericTaskTypeMapper is not support {typeSymbol.ToDisplayString()}.");
     }
+
+    public bool IsSupported()
+    {
+        return this.Assign is not null;
+    }
 }
 
 public sealed class ChannelReaderTypeMapper : ITypeMapper
@@ -49,5 +54,10 @@ public sealed class ChannelReaderTypeMapper : ITypeMapper
         }
 
         throw new InvalidOperationException($"GenericTaskTypeMapper is not support {typeSymbol.ToDisplayString()}.");
+    }
+
+    public bool IsSupported()
+    {
+        return this.Assign is not null;
     }
 }


### PR DESCRIPTION
By default, netstandard2.0 does not include `IAsyncEnumerable<T>` and `ChannelReader<T>`.
Therefore, there was an issue when defining the interface in the netstandard2.0 project.

Related: #107.