### PR TITLE
add ts-ignore to avoid "TS7030: Not all code paths return a value."

### DIFF
--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
@@ -74,7 +74,7 @@ export type HubProxyFactoryProvider = {
             this.Write(this.ToStringHelper.ToStringWithCulture(hubType.Name));
             this.Write(">;\r\n");
  } 
-            this.Write("}\r\n\r\nexport const getHubProxyFactory = ((hubType: string) => {\r\n");
+            this.Write("}\r\n\r\n// @ts-ignore\r\nexport const getHubProxyFactory = ((hubType: string) => {\r\n");
  foreach(var hubType in HubTypes) { 
             this.Write("    if(hubType === \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(hubType.Name));
@@ -90,7 +90,8 @@ export type HubProxyFactoryProvider = {
             this.Write(this.ToStringHelper.ToStringWithCulture(receiverType.Name));
             this.Write(">;\r\n");
  } 
-            this.Write("}\r\n\r\nexport const getReceiverRegister = ((receiverType: string) => {\r\n");
+            this.Write("}\r\n\r\n// @ts-ignore\r\nexport const getReceiverRegister = ((receiverType: string) =>" +
+                    " {\r\n");
  foreach(var receiverType in ReceiverTypes) { 
             this.Write("    if(receiverType === \"");
             this.Write(this.ToStringHelper.ToStringWithCulture(receiverType.Name));

--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
@@ -50,6 +50,7 @@ export type HubProxyFactoryProvider = {
 <# } #>
 }
 
+// @ts-ignore
 export const getHubProxyFactory = ((hubType: string) => {
 <# foreach(var hubType in HubTypes) { #>
     if(hubType === "<#= hubType.Name #>") {
@@ -64,6 +65,7 @@ export type ReceiverRegisterProvider = {
 <# } #>
 }
 
+// @ts-ignore
 export const getReceiverRegister = ((receiverType: string) => {
 <# foreach(var receiverType in ReceiverTypes) { #>
     if(receiverType === "<#= receiverType.Name #>") {


### PR DESCRIPTION
When using the generated code in my project, I'm getting a `TS7030: Not all code paths return a value.` on the definitions of `getHubProxyFactory()` and `getReceiverRegister()` since they only return a value if the `hubType` / `receiverType` match. Otherwise, they don't return any value at all. Adding a `// @ts-ignore` suppresses the error. Another option would be to change the return type to also allow `undefined` and return `undefined` if the `hubType` / `receiverType` doesn't match.