### PR TITLE
Update to support CancellationToken

### DIFF
--- a/src/TypedSignalR.Client.TypeScript.Analyzer/InterfaceAnalyzer.cs
+++ b/src/TypedSignalR.Client.TypeScript.Analyzer/InterfaceAnalyzer.cs
@@ -226,6 +226,11 @@ public class InterfaceAnalyzer : DiagnosticAnalyzer
 
             foreach (var parameter in method.Parameters)
             {
+                if (SymbolEqualityComparer.Default.Equals(parameter.Type, specialSymbols.CancellationTokenSymbol))
+                {
+                    continue;
+                }
+
                 ValidateType(context, parameter.Type, parameter.Locations[0], supportTypeSymbols, transpilationSourceAttributeSymbol);
             }
         }

--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.cs
@@ -138,7 +138,7 @@ export type HubProxyFactoryProvider = {
             this.Write("        const __");
             this.Write(this.ToStringHelper.ToStringWithCulture(method.Name.Format(Options.NamingStyle)));
             this.Write(" = ");
-            this.Write(this.ToStringHelper.ToStringWithCulture(method.WrapLambdaExpressionSyntax(Options)));
+            this.Write(this.ToStringHelper.ToStringWithCulture(method.WrapLambdaExpressionSyntax(SpecialSymbols, Options)));
             this.Write(";\r\n");
  } 
             this.Write("\r\n");

--- a/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
+++ b/src/TypedSignalR.Client.TypeScript/Templates/ApiTemplate.tt
@@ -111,7 +111,7 @@ class <#= receiverType.Name #>_Binder implements ReceiverRegister<<#= receiverTy
     public readonly register = (connection: HubConnection, receiver: <#= receiverType.Name #>): Disposable => {
 
 <# foreach(var method in receiverType.Methods) { #>
-        const __<#= method.Name.Format(Options.NamingStyle) #> = <#= method.WrapLambdaExpressionSyntax(Options) #>;
+        const __<#= method.Name.Format(Options.NamingStyle) #> = <#= method.WrapLambdaExpressionSyntax(SpecialSymbols, Options) #>;
 <# } #>
 
 <# foreach(var method in receiverType.Methods) { #>


### PR DESCRIPTION
Hello, I was running into issues while attempting to generate my TypeScript when my receiver interface had a CancellatonToken parameter. Upon investigation, I only found this issue https://github.com/nenoNaninu/TypedSignalR.Client.TypeScript/issues/87 but no solution was mentioned. In my use case the CancellationToken is found on the Receiver and not the Hub, and I am not streaming. I am opening this PR to allow the generation with CancellationToken, and updating the analyzer to ignore CancellationTokens found on the Receiver