### PR TITLE
use Cocona instead of ConsoleAppFramework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,6 +6,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageVersion Include="AspNetCore.SignalR.OpenTelemetry" Version="1.4.0" />
+        <PackageVersion Include="Cocona" Version="2.2.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.8.0" />
         <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.8.0" />
@@ -23,7 +24,6 @@
         <PackageVersion Include="TypedSignalR.Client.Attributes" Version="1.1.0" />
         <PackageVersion Include="TypedSignalR.Client.DevTools" Version="1.2.4" />
         <PackageVersion Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-        <PackageVersion Include="ConsoleAppFramework" Version="4.2.4" />
         <PackageVersion Include="MessagePack" Version="2.5.187" />
         <PackageVersion Include="MessagePack.AspNetCoreMvcFormatter" Version="2.5.129" />
     </ItemGroup>

--- a/src/TypedSignalR.Client.TypeScript.Generator/App.cs
+++ b/src/TypedSignalR.Client.TypeScript.Generator/App.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Cocona;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using Microsoft.CodeAnalysis;
@@ -14,7 +15,7 @@ using TypedSignalR.Client.TypeScript.TypeMappers;
 
 namespace TypedSignalR.Client.TypeScript;
 
-public class App : ConsoleAppBase
+public class App : CoconaConsoleAppBase
 {
     private readonly ILogger<App> _logger;
 
@@ -23,25 +24,24 @@ public class App : ConsoleAppBase
         _logger = logger;
     }
 
-    [RootCommand]
     public async Task Transpile(
-        [Option("p", "Path to the project file (XXX.csproj)")]
+        [Option('p', Description = "Path to the project file (XXX.csproj)")]
         string project,
-        [Option("o", "Output directory")]
+        [Option('o', Description ="Output directory")]
         string output,
-        [Option("eol", "lf / crlf / cr")]
+        [Option("eol", Description ="lf / crlf / cr")]
         NewLineOption newLine = NewLineOption.Lf,
-        [Option("asm", "Flag whether to extend the transpile target to the referenced assembly.")]
+        [Option("asm", Description ="Flag whether to extend the transpile target to the referenced assembly.")]
         bool assemblies = false,
-        [Option("s", "JSON / MessagePack : The output type will be suitable for the selected serializer.")]
+        [Option('s', Description ="JSON / MessagePack : The output type will be suitable for the selected serializer.")]
         SerializerOption serializer = SerializerOption.Json,
-        [Option("n", "camelCase (default) / PascalCase / none (The name in C# is used as it is.)")]
+        [Option('n', Description ="camelCase (default) / PascalCase / none (The name in C# is used as it is.)")]
         NamingStyle namingStyle = NamingStyle.CamelCase,
-        [Option("en", "value (default) / name / nameCamel / NamePascal / union / unionCamel / UnionPascal")]
+        [Option(Description ="value (default) / name / nameCamel / NamePascal / union / unionCamel / UnionPascal")]
         EnumStyle @enum = EnumStyle.Value,
-        [Option("m", "camelCase (default) / PascalCase / none (The name in C# is used as it is.)")]
+        [Option('m', Description = "camelCase (default) / PascalCase / none (The name in C# is used as it is.)")]
         MethodStyle method = MethodStyle.CamelCase,
-        [Option("attr", "The flag whether attributes such as JsonPropertyName should affect transpilation.")]
+        [Option("attr", Description ="The flag whether attributes such as JsonPropertyName should affect transpilation.")]
         bool attribute = true)
     {
         _logger.Log(LogLevel.Information, "Start loading the csproj of {path}.", Path.GetFullPath(project));

--- a/src/TypedSignalR.Client.TypeScript.Generator/Program.cs
+++ b/src/TypedSignalR.Client.TypeScript.Generator/Program.cs
@@ -1,9 +1,18 @@
+using Cocona;
 using Microsoft.Build.Locator;
+using Microsoft.Extensions.Logging;
 using TypedSignalR.Client.TypeScript;
 
 MSBuildLocator.RegisterDefaults();
 
-var app = ConsoleApp.Create(args);
+var builder = CoconaApp.CreateBuilder();
+
+builder.Logging.AddSimpleConsole(options =>
+{
+    options.SingleLine = true;
+});
+
+var app = builder.Build();
 
 app.AddCommands<App>();
 

--- a/src/TypedSignalR.Client.TypeScript.Generator/TypedSignalR.Client.TypeScript.Generator.csproj
+++ b/src/TypedSignalR.Client.TypeScript.Generator/TypedSignalR.Client.TypeScript.Generator.csproj
@@ -22,7 +22,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="ConsoleAppFramework" />
+        <PackageReference Include="Cocona" />
         <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
         <PackageReference Include="Microsoft.Build.Locator" />
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />


### PR DESCRIPTION
ConsoleAppFramework v4 is outdated. I needed to migrate to v5, but instead of migrating to v5 I decided to use Cocona.